### PR TITLE
Add the posibility to send events to a named tracker.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ga",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Google Analytics for your Angular application",
   "license": "MIT",
   "repository": "SamVerschueren/angular-ga",

--- a/src/lib/interfaces/tracking-options.ts
+++ b/src/lib/interfaces/tracking-options.ts
@@ -1,5 +1,6 @@
 export interface TrackingOptions {
 	name?: string;
+	namedTracker: boolean;
 	storage?: string;
 	clientId?: string;
 	sampleRate?: number;


### PR DESCRIPTION
Hello, I like this library, it is easy to use and set up quickly and it has the possibility to change the trackerId dynamically.
While playing around with this application I haven't found a way to send events to a named tracker.
I created a pull request with changes to be able to do this.

More information about named tracker can be found [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/accessing-trackers).