### PR TITLE
Configure without pageview

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ export class AppComponent implements OnInit {
 
 ## API
 
-### service.configure(trackingId, [options])
+### service.configure(trackingId, [options], [sendPageview])
 
 #### trackingId
 
@@ -122,6 +122,13 @@ Type: `Object` `string`<br>
 Default: `auto`
 
 Any of the [`Create Only Fields`](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#create).
+
+#### sendPageview
+
+Type: `Boolean`<br>
+Default: `true`
+
+Set this to false to prevent automatically sending a pageview when configuring the service.
 
 ### service.event.emit(event: Event)
 

--- a/src/lib/ga.service.ts
+++ b/src/lib/ga.service.ts
@@ -22,9 +22,12 @@ export class GoogleAnalyticsService {
 		}
 	}
 
-	configure(trackingId: string, options: TrackingOptions | string = 'auto'): void {
+	configure(trackingId: string, options: TrackingOptions | string = 'auto', sendPageview = true): void {
 		this.ga('create', trackingId, options);
-		this.ga('send', 'pageview');
+
+		if (sendPageview){
+			this.ga('send', 'pageview');
+		}
 
 		this.event.subscribe((x: Event) => {
 			this.onEvent(x);


### PR DESCRIPTION
Added an optional parameter to remove sending a pageview when calling the configure method.

Closes #7 