### PR TITLE
Allow higher Angular versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"ganalytics"
 	],
 	"peerDependencies": {
-		"@angular/core": "^8.0.0"
+		"@angular/core": ">= 8"
 	},
 	"devDependencies": {
 		"@angular/common": "^8.0.0",


### PR DESCRIPTION
Currently it throws e.g. "Package "angular-ga" has an incompatible peer dependency to "@angular/core" (requires "^8.0.0" (extended), would install "10.2.4")." while trying to update to Angular 10.