### PR TITLE
Allow newer major Angular versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"ganalytics"
 	],
 	"peerDependencies": {
-		"@angular/core": "^8.0.0"
+		"@angular/core": ">= 8.0.0"
 	},
 	"devDependencies": {
 		"@angular/common": "^8.0.0",


### PR DESCRIPTION
Now, when trying to `ng update` to versions > 8, developers will get the following console error:
> Package "angular-ga" has an incompatible peer dependency to "@angular/core" (requires "^8.0.0" (extended), would install "12.1.1").
> ✖ Migration failed: Incompatible peer dependencies found.

This PR resolves this. Please create a new npm release as well.